### PR TITLE
features/moveDetails: fixed Tile layout on mobile, @media relates to theme

### DIFF
--- a/src/common/Tile/Tile.js
+++ b/src/common/Tile/Tile.js
@@ -6,14 +6,17 @@ export const Tile = styled.article`
 	margin-top: 64px;
 	display: grid;
 	grid-template-columns: auto 1fr;
-	gap: 40px;
+	grid-template-rows: auto 1fr;
+	column-gap: 40px;
+	grid-row-gap: 0;
 	padding: 40px;
 	background-color: ${({ theme }) => theme.color.white};
 	box-shadow: 0px 4px 12px 0px rgba(186, 199, 213, 0.5);
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		margin-top: 16px;
-		gap: 16px;
+		column-gap: 16px;
+		grid-row-gap: 0;
 		padding: 16px;
 	}
 `
@@ -28,7 +31,7 @@ export const SmallTile = styled.article`
 	background-color: ${({ theme }) => theme.color.white};
 	box-shadow: 0px 4px 12px 0px rgba(186, 199, 213, 0.5);
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		width: 136px;
 		padding: 8px;
 	}
@@ -44,7 +47,7 @@ export const SmallTileImageContainer = styled.div`
 	background: ${({ theme }) => theme.color.silver};
 	color: ${({ theme }) => theme.color.white};
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		width: 120px;
 		height: 178px;
 	}
@@ -56,7 +59,7 @@ export const SmallTileImage = styled.img`
 	background: ${({ theme }) => theme.color.silver};
 	color: ${({ theme }) => theme.color.white};
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		width: 120px;
 	}
 `
@@ -65,7 +68,7 @@ export const NoPersonIcon = styled(NoPersonSVG)`
 	width: 72px;
 	height: 72px;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		width: 48px;
 		height: 48px;
 	}
@@ -75,7 +78,7 @@ export const NoMovieIcon = styled(NoMovieSVG)`
 	width: 72px;
 	height: 72px;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		width: 48px;
 		height: 48px;
 	}
@@ -86,21 +89,24 @@ export const TileImage = styled.img`
 	height: 464px;
 	border-radius: 5px;
 	background-color: ${({ theme }) => theme.color.silver};
+	grid-row: 1 / 3;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
+		grid-row: 1 / 2;
 		width: 114px;
 		height: 169px;
 	}
 `
 
 export const TileContent = styled.div`
-	padding: 8px 0;
+	padding-top: 8px;
 	display: flex;
 	flex-direction: column;
+	justify-content: left;
 	gap: 24px;
-	flex-wrap: nowrap;
-
-	@media (max-width: 767px) {
+	
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
+		padding-top: 0px;
 		gap: 4px;
 	}
 `
@@ -111,7 +117,7 @@ export const TileTitle = styled.h2`
 	font-weight: 600;
 	line-height: 1.2;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		font-size: 16px;
 		font-weight: 500;
 		line-height: 1.3;
@@ -127,7 +133,7 @@ export const SmallTileTitle = styled.h2`
 	line-height: 1.3;
 	color: ${({ theme }) => theme.color.almostBlack};
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		font-size: 14px;
 	}
 `
@@ -138,7 +144,7 @@ export const TileSubTitle = styled.h3`
 	line-height: 1.2;
 	height: auto;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		font-size: 13px;
 		line-height: 1.3;
 		color: ${({ theme }) => theme.color.darkGray};
@@ -154,7 +160,7 @@ export const SmallTileSubTitle = styled.h3`
 	color: ${({ theme }) => theme.color.darkGray};
 
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		font-size: 13px;
 		line-height: 1.3;
 	}
@@ -166,7 +172,7 @@ export const TileData = styled.div`
 	gap: 8px;
 	max-height: 52px;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		margin-top: 4px;
 	}
 `
@@ -177,7 +183,7 @@ export const TileDataContent = styled.p`
 	font-size: 18px;
 	line-height: 1.2;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		font-size: 12px;
 		line-height: 1.3;
 	}
@@ -187,7 +193,7 @@ export const TileDataTitle = styled.span`
 	padding-right: 10px;
 	color: ${({ theme }) => theme.color.slateGray};
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		display: none;
 	}
 `
@@ -197,7 +203,7 @@ export const TileTags = styled.div`
 	flex-wrap: wrap;
 	gap: 16px;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		margin: 4px 0;
 		gap: 8px;
 	}
@@ -213,7 +219,7 @@ export const TileTag = styled.div`
 	font-size: 14px;
 	line-height: 1;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
 		padding: 4px 8px;
 		font-size: 10px;
 		line-height: 1.1;
@@ -221,12 +227,15 @@ export const TileTag = styled.div`
 `
 
 export const Description = styled.p`
-	margin: 0;
+	margin: 24px 0 0 0;
 	padding: 0;
 	font-size: 20px;
 	line-height: 1.6;
 
-	@media (max-width: 767px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobile}px) {
+		margin: 16px 0 0 0;
+		grid-column: 1 / 3;
+		grid-row: 2 / 3;
 		font-size: 14px;
 	}
 `

--- a/src/features/movies/MovieDetails/index.js
+++ b/src/features/movies/MovieDetails/index.js
@@ -98,9 +98,9 @@ function MovieDetails() {
               })}
               isOnBackdrop={false}
               isOnMainTile={true}
-            />
-            <Description>{movieDetails.description}</Description>
+            />            
           </TileContent>
+          <Description>{movieDetails.description}</Description>
         </Tile>
         <Section>
           <SectionTitle>Cast</SectionTitle>


### PR DESCRIPTION
I still need to work on edge cases.
For instance on window widths just above mobile the layout brakes a little if _Production:_ counties word-brake to a second line.
It seems we might need spend some time optimising the App to all cases and screen sizes 😛 