### PR TITLE
Page limit set to 500pages

### DIFF
--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -11,6 +11,7 @@ import {
 	RegularText,
 	BoldText,
 } from './styled';
+import pageLimit from "../../utils/pageLimit";
 
 const Pagination = ({ currentPage, goToFirstPage, decrementPage, incrementPage }) => {
 	const dispatch = useDispatch();
@@ -36,13 +37,18 @@ const Pagination = ({ currentPage, goToFirstPage, decrementPage, incrementPage }
 				<RegularText>Page</RegularText>
 				<BoldText>{currentPage}</BoldText>
 				<RegularText>of</RegularText>
-				<BoldText>500</BoldText>
+				<BoldText>{pageLimit}</BoldText>
 			</TextContainer>
-			<StyledButton onClick={() => dispatch(incrementPage())}>
+			<StyledButton 
+				onClick={() => dispatch(incrementPage())}
+				disabled={currentPage > (pageLimit - 1)}
+			>
 				<ButtonText>Next</ButtonText>
 				<Chevron />
 			</StyledButton>
-			<StyledButton disabled={true}>
+			<StyledButton 
+				disabled={currentPage > (pageLimit - 1)}
+			>
 				<ButtonText>Last</ButtonText>
 				<Chevron />
 				<MobileChevron />

--- a/src/utils/pageLimit.js
+++ b/src/utils/pageLimit.js
@@ -1,0 +1,1 @@
+export default 500;

--- a/src/utils/pageLimit.js
+++ b/src/utils/pageLimit.js
@@ -1,1 +1,6 @@
+//As of Jan 2024 TMDB sets an upper-limit on page number one can request from API.
+//Any query for page above #500 gives the following response:
+//"status_message": "Invalid page: Pages start at 1 and max at 500. They are expected to be an integer.",
+//hence a hardcoded integer below.
+
 export default 500;


### PR DESCRIPTION
Even though the API returns the sum of results and the number of pages with results, a request to a page larger than 500 gives the following response:

```
{
  "success": false,
  "status_code": 22,
  "status_message": "Invalid page: Pages start at 1 and max at 500. They are expected to be an integer."
}
```

So I simply added a file with a limit of 500 and imported this value where we want to limit the query.
I didn't find any possible request to the API about the maximum number of pages available, so I don't know how to automate it, I guess for now 500 must be entered manually.