### PR TITLE
fetch URLs changed to outbound - pre GH Pages deploy

### DIFF
--- a/src/features/movies/MovieList/getPopularMovies.js
+++ b/src/features/movies/MovieList/getPopularMovies.js
@@ -1,7 +1,5 @@
 import { popularMoviesURL } from "../../../utils/API/APIURLS";
 
-// const JSON_URL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/movies.json";
-
 export const getPopularMovies = async (page) => {
     try {
         const response = await fetch(`${popularMoviesURL}&page=${page}`);

--- a/src/features/movies/getMovieDetails.js
+++ b/src/features/movies/getMovieDetails.js
@@ -1,14 +1,11 @@
-// to fetch data from API use those imports with passed { id }
-// import { URL, AuthorizationAndLanguage } from "../../utils/API/APIURLS";
+import { URL, AuthorizationAndLanguage } from "../../utils/API/APIURLS";
 
-const movieDetailSampleURL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/movie-466420.json";
-const movieCreditsSampleURL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/credits-466420.json";
+// const movieDetailSampleURL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/movie-466420.json";
+// const movieCreditsSampleURL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/credits-466420.json";
 
-export const getMovieDetails = async (/* id */) => {
+export const getMovieDetails = async ( id ) => {
 
-    //const movieDetailURL = `${URL}movie/${id}${AuthorizationAndLanguage}`;
-
-    const response = await fetch(movieDetailSampleURL);
+    const response = await fetch(`${URL}movie/${id}${AuthorizationAndLanguage}`);
 
     if (!response.ok) {
         new Error(response.statusText);
@@ -17,11 +14,9 @@ export const getMovieDetails = async (/* id */) => {
     return await response.json();
 };
 
-export const getMovieCredits = async () => {
+export const getMovieCredits = async ( id ) => {
 
-    //const movieCreditsURL = `${URL}movie/${id}/credits${AuthorizationAndLanguage}`;
-
-    const response = await fetch(movieCreditsSampleURL);
+    const response = await fetch(`${URL}movie/${id}/credits${AuthorizationAndLanguage}`);
 
     if (!response.ok) {
         new Error(response.statusText);

--- a/src/features/people/getPeopleData.js
+++ b/src/features/people/getPeopleData.js
@@ -1,12 +1,8 @@
-// to fetch data from API use below import with passed { page }
-// await fetch(`${popularPeopleURL}&page=${page}`);
-// import { popularPeopleURL } from "../../utils/API/APIURLS";
+import { popularPeopleURL } from "../../utils/API/APIURLS";
 
-const poepleListSampleURL = "https://raw.githubusercontent.com/bedicooper/movies-browser/main/public/people.json";
+export const getPeopleData = async ( page ) => {
 
-export const getPeopleData = async (/*page*/) => {
-
-  const response = await fetch(poepleListSampleURL);
+  const response = await fetch(`${popularPeopleURL}&page=${page}`);
 
   if (!response.ok) {
     new Error(response.statusText);


### PR DESCRIPTION
In preparation for GHPages deploy I've changed the URLs in fetching functions to send request to API rather then local samples. 