### PR TITLE
fixed a bug that displayed original titles in movieDetails

### DIFF
--- a/src/features/movies/customiseMovieDetails.js
+++ b/src/features/movies/customiseMovieDetails.js
@@ -18,7 +18,7 @@ export const customiseMovieDetails = (movieDetails) => {
             backdropURL: `${backdropURL}${movieDetails.backdrop_path}`,
             posterPath: movieDetails.poster_path,
             posterURL: `${posterURL}${movieDetails.poster_path}`,
-            title: movieDetails.original_title,
+            title: movieDetails.title,
             releaseYear: justYear,
             releaseDate: formattedDate,
             production: productionCountries,


### PR DESCRIPTION
My bad, I was assiging the original_title while there was a property with an English title in the API