### PR TITLE
added loading state on page change in Movies and People Lists

### DIFF
--- a/src/features/movies/MovieList/movieListSlice.js
+++ b/src/features/movies/MovieList/movieListSlice.js
@@ -12,18 +12,23 @@ const movieListSlice = createSlice({
     reducers: {
         incrementPage: (state) => {
 			state.page += 1;
+            state.loading = true;
 		},
 		decrementPage: (state) => {
 			state.page -= 1;
+            state.loading = true;
 		},
         goToFirstPage: (state) => {
             state.page = 1;
+            state.loading = true;
         },
         goToLastPage: (state, {payload: lastPage}) => {
             state.page = +lastPage;
+            state.loading = true;
         },
 		pageNumberFromURL: (state, { payload: query }) => {
 			state.page = +query;
+            state.loading = true;
 		},
         setMovieList: (state, { payload: movies }) => {
             state.movies = movies;
@@ -50,9 +55,10 @@ export const {
     setLoading,
 } = movieListSlice.actions;
 
-export const selectMovieListState = state => state.movieList;
-export const selectMovieList = state => selectMovieListState(state).movies;
-export const selectLoading = state => selectMovieListState(state).loading;
+const selectMovieListState = (state) => state.movieList;
+
+export const selectMovieList = (state) => selectMovieListState(state).movies;
+export const selectLoading = (state) => selectMovieListState(state).loading;
 export const selectPageState = (state) => selectMovieListState(state).page;
 
 export default movieListSlice.reducer;

--- a/src/features/people/PeopleList/index.js
+++ b/src/features/people/PeopleList/index.js
@@ -9,17 +9,20 @@ import {
   pageNumberFromURL,
   selectPageState,
   selectPeopleList,
+  selectLoading,
 } from '../peopleSlice';
 import { Main } from '../../../common/Main/Main';
 import { Section, SectionTitle } from "../../../common/Section/Section";
 import { SmallListWrapper, StyledLink } from '../../../common/Tile/styled';
 import { ListTileSmall } from '../../../common/Tile';
 import Pagination from '../../../common/Pagination';
+import { Container, SpinnerIcon } from '../../../common/Loading/Loading';
 
 function PeopleList() {
   const dispatch = useDispatch();
   const currentPage = useSelector(selectPageState);
   const peopleList = useSelector(selectPeopleList);
+  const loading = useSelector(selectLoading);
 
   const history = useHistory();
   const location = useLocation();
@@ -38,6 +41,14 @@ function PeopleList() {
 
     history.push(`${location.pathname}?page=${currentPage}`);
   }, [currentPage]);
+
+  if (loading) {
+    return (
+      <Container>
+        <SpinnerIcon />
+      </Container>
+    )
+  };
 
   return (
     <Main>

--- a/src/features/people/peopleSlice.js
+++ b/src/features/people/peopleSlice.js
@@ -11,23 +11,29 @@ const peopleSlice = createSlice({
 		},
     },
 	reducers: {
-		incrementPage: (state) => {
+        incrementPage: (state) => {
 			state.page += 1;
+            state.loading = true;
 		},
 		decrementPage: (state) => {
 			state.page -= 1;
+            state.loading = true;
 		},
         goToFirstPage: (state) => {
             state.page = 1;
+            state.loading = true;
         },
-		goToLastPage: (state, {payload: lastPage}) => {
+        goToLastPage: (state, {payload: lastPage}) => {
             state.page = +lastPage;
+            state.loading = true;
         },
 		pageNumberFromURL: (state, { payload: query }) => {
 			state.page = +query;
+            state.loading = true;
 		},
 		setPeopleList: (state, {payload: peopleList}) => {
             state.peopleList = peopleList;
+			state.loading = false;
         },
 	},
 });
@@ -45,5 +51,7 @@ const selectPeopleState = (state) => state.people;
 
 export const selectPageState = (state) => selectPeopleState(state).page;
 export const selectPeopleList = (state) => selectPeopleState(state).peopleList.results;
+export const selectLoading = (state) => selectPeopleState(state).loading;
+
 
 export default peopleSlice.reducer;


### PR DESCRIPTION
Previously after changing the page using pagination the list would rerender but window stayed on the bottom of the page (where we clicked on pagination button) and user would have to scroll up to see the list. Now with loading state implementation when list renders with new results we end up at the top of the list.