### PR TITLE
refactor of Loading component to simplefy imports in app features

### DIFF
--- a/src/common/Loading/index.js
+++ b/src/common/Loading/index.js
@@ -1,0 +1,7 @@
+import { Container, SpinnerIcon } from "./styled"
+
+export default Loading() = (
+    < Container >
+        <SpinnerIcon />
+    </Container >
+);

--- a/src/common/Loading/styled.js
+++ b/src/common/Loading/styled.js
@@ -1,0 +1,34 @@
+import styled, { keyframes } from "styled-components";
+import { ReactComponent as SpinnerSVG } from "../../assets/icon-spinner.svg";
+
+const rotate = keyframes`   
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+`
+
+export const SpinnerIcon = styled(SpinnerSVG)`
+	margin: auto;
+    width: 91px;
+	height: 91px;
+    pointer-events: none;
+    animation: ${rotate} infinite 800ms linear;
+
+    @media (max-width: 767px) {
+        width: 35px;
+	    height: 35px;
+	}
+`
+
+export const Container = styled.div`
+    display: flex;
+    position: relative;
+    top: 219px;
+
+    @media (max-width: 767px) {
+        top: 66px;
+	}
+`


### PR DESCRIPTION
Hi, I've split the Loading.js file into index and styled, as using only `<Loading />` in features instead of `<Container><SpinnerIcon /></Container>` is a much cleaner solution and it is time to exit prototyping fase 😉 

I've left the Loading.js file for now - we will delete it once we update imports in all features.