### PR TITLE
fixed loading state on Movie Details render

### DIFF
--- a/src/features/movies/movieSlice.js
+++ b/src/features/movies/movieSlice.js
@@ -11,6 +11,7 @@ const movieSlice = createSlice({
     reducers: {
         setMovieId: (state, {payload: id}) => {
             state.id = id;
+            state.loading = true;
         },
         setMovieDetails: (state, {payload: movieDetails}) => {
             state.details = movieDetails;


### PR DESCRIPTION
Similarly to pages with lists, the loading status did not always work correctly and sometimes the bottom of the page with movie details was shown on render.