### PR TITLE
common/Tile added a unique "key" prop to Tags in DetailsTile

### DIFF
--- a/src/common/Tile/index.js
+++ b/src/common/Tile/index.js
@@ -190,7 +190,7 @@ export const DetailsTile = (
 					<>
 						<TileTags>
 							{tags.map(({ name }) => (
-								<TileTag>{name}</TileTag>
+								<TileTag key={name}>{name}</TileTag>
 							))}
 						</TileTags>
 						<Rating


### PR DESCRIPTION
I've corrected that one lingering warning that appears on console in Movie Details, that each child in a list should have a unique "key" prop.