### PR TITLE
Common/navigation active link cursor

### DIFF
--- a/src/Navigation/Header/styled.js
+++ b/src/Navigation/Header/styled.js
@@ -90,6 +90,7 @@ export const StyledNavLink = styled(NavLink)`
     &.active{
         border: 1px solid ${({ theme }) => theme.color.white};
         background: none;
+        cursor: auto;
     };
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}px){

--- a/src/Navigation/Header/styled.js
+++ b/src/Navigation/Header/styled.js
@@ -90,7 +90,7 @@ export const StyledNavLink = styled(NavLink)`
     &.active{
         border: 1px solid ${({ theme }) => theme.color.white};
         background: none;
-        cursor: auto;
+        cursor: default;
     };
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileMax}px){


### PR DESCRIPTION
Hi, just a small enhancement.
I've noticed that active Links do not work like non active ones IE clicking them does not reload/refresh the page.
I suggest changeing the cursor on active Links to default. I've tried `cursor: auto;` but it changes to a default arrow except on letters when it changes to `text `type.