### PR TITLE
prevent searchSaga to request empty string on input reset

### DIFF
--- a/src/common/Navigation/Search/searchSaga.js
+++ b/src/common/Navigation/Search/searchSaga.js
@@ -25,24 +25,25 @@ function* fetchDataHandler() {
             select(selectPath),
             select(selectCurrnetPage),
         ]);
-        const [rawSearchResults, rawGenreList] = yield all([
-            call(getSearch, query, path, page),
-            call(getGenreList),
-        ])
-        const result = yield call(
-            processSearchResults,
-            rawSearchResults,
-            rawGenreList,
-            path
-        );
+        if (query !== '') {
+            const [rawSearchResults, rawGenreList] = yield all([
+                call(getSearch, query, path, page),
+                call(getGenreList),
+            ])
+            const result = yield call(
+                processSearchResults,
+                rawSearchResults,
+                rawGenreList,
+                path
+            );
 
-        yield all([
-            put(fetchDataSucces(result)),
-            put(setGenres(rawGenreList)),
-            put(setTotalPages(rawSearchResults)),
-            put(setTotalResults(rawSearchResults)),
-        ]);
-
+            yield all([
+                put(fetchDataSucces(result)),
+                put(setGenres(rawGenreList)),
+                put(setTotalPages(rawSearchResults)),
+                put(setTotalResults(rawSearchResults)),
+            ]);
+        }
     } catch (error) {
         yield put(fetchDataFailure(error.message));
     };
@@ -58,5 +59,5 @@ export function* searchSaga() {
             goToLastSearchPage,
         ],
         fetchDataHandler
-    )
-}
+    );
+};


### PR DESCRIPTION
I've added a silmple if statement to check if query is not empty. 
I've abandoned my previous idea with another generator that checks action.payload as it worked once and then stoped with an error: Actions must be plain objects.
Now I think it should work as intened because if inputValue is an empty string, it will skip the subsequent logic, so **fetchDataHandler** will only execute to the and if inputValue is not empty