### PR TITLE
Common/use url params in search

### DIFF
--- a/src/common/Navigation/Search/index.js
+++ b/src/common/Navigation/Search/index.js
@@ -3,7 +3,18 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { usePathname } from "./usePathname";
 import { Wrapper, Input, Icon } from "./styled";
-import { selectInputValue, selectPath, setInputValue } from "./searchSlice";
+import { 
+    selectInputValue, 
+    selectPath, 
+    setInputValue, 
+    selectCurrnetPage 
+} from "./searchSlice";
+import { 
+    useURLParameter, 
+    useReplaceQueryParameter 
+} from "../../../utils/useURLParams";
+import paginationParamName from "../../../utils/paginationParamName";
+import queryParamName from "../../../utils/queryParamName";
 
 export const Search = () => {
     const location = useLocation();
@@ -12,6 +23,18 @@ export const Search = () => {
 
     const path = useSelector(selectPath);
     const inputValue = useSelector(selectInputValue);
+    const currentPage = useSelector(selectCurrnetPage);
+
+    const pageParam = useURLParameter(paginationParamName);
+    const query = useURLParameter(queryParamName);
+    const replaceQueryParameter = useReplaceQueryParameter();
+
+    const params = {
+        pageKey: paginationParamName,
+        pageValue: currentPage,
+        queryKey: queryParamName,
+        queryValue: inputValue
+    };
 
     useEffect(() => {
         updatePath();
@@ -19,11 +42,15 @@ export const Search = () => {
 
     const onInputChange = ({ target }) => {
         const trimmedValue = target.value.trim();
-        
+
         if (trimmedValue.length !== 0) {
             dispatch(setInputValue(target.value));
         } else dispatch(setInputValue(trimmedValue));
     };
+
+    useEffect(() => {
+        replaceQueryParameter(params);
+    }, [inputValue, currentPage, query, pageParam])
 
     return (
         <Wrapper>

--- a/src/common/Navigation/Search/index.js
+++ b/src/common/Navigation/Search/index.js
@@ -3,16 +3,17 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { usePathname } from "./usePathname";
 import { Wrapper, Input, Icon } from "./styled";
-import { 
-    selectInputValue, 
-    selectPath, 
-    setInputValue, 
-    selectCurrnetPage 
+import {
+    selectInputValue,
+    selectPath,
+    setInputValue,
+    selectCurrnetPage
 } from "./searchSlice";
-import { 
+import {
     useURLParameter,
-    useUpdateQueryFromURL, 
-    useReplaceQueryParameter 
+    useUpdatePageFromURL,
+    useUpdateQueryFromURL,
+    useReplaceQueryParameter
 } from "../../../utils/useURLParams";
 import paginationParamName from "../../../utils/paginationParamName";
 import queryParamName from "../../../utils/queryParamName";
@@ -30,6 +31,7 @@ export const Search = () => {
     const query = useURLParameter(queryParamName);
     const replaceQueryParameter = useReplaceQueryParameter();
     const updateQueryFromURL = useUpdateQueryFromURL();
+    const updatePageFromURL = useUpdatePageFromURL();
 
     const params = {
         pageKey: paginationParamName,
@@ -42,9 +44,20 @@ export const Search = () => {
         updatePath();
     }, [location.pathname]);
 
-    useEffect(()=>{
-        updateQueryFromURL(pageParam, query)
-    },[pageParam, query]);
+    useEffect(() => {
+        updatePageFromURL({
+            key: "search",
+            value: +pageParam,
+        });
+    }, [pageParam]);
+
+    useEffect(() => {
+        updateQueryFromURL(query)
+    }, [query]);
+  
+    useEffect(() => {
+        replaceQueryParameter(params);
+    }, [inputValue, currentPage, query, pageParam]);
 
     const onInputChange = ({ target }) => {
         const trimmedValue = target.value.trim();
@@ -53,10 +66,6 @@ export const Search = () => {
             dispatch(setInputValue(target.value));
         } else dispatch(setInputValue(trimmedValue));
     };
-
-    useEffect(() => {
-        replaceQueryParameter(params);
-    }, [inputValue, currentPage, query, pageParam]);
 
     return (
         <Wrapper>

--- a/src/common/Navigation/Search/index.js
+++ b/src/common/Navigation/Search/index.js
@@ -10,7 +10,8 @@ import {
     selectCurrnetPage 
 } from "./searchSlice";
 import { 
-    useURLParameter, 
+    useURLParameter,
+    useUpdateQueryFromURL, 
     useReplaceQueryParameter 
 } from "../../../utils/useURLParams";
 import paginationParamName from "../../../utils/paginationParamName";
@@ -28,17 +29,22 @@ export const Search = () => {
     const pageParam = useURLParameter(paginationParamName);
     const query = useURLParameter(queryParamName);
     const replaceQueryParameter = useReplaceQueryParameter();
+    const updateQueryFromURL = useUpdateQueryFromURL();
 
     const params = {
         pageKey: paginationParamName,
         pageValue: currentPage,
         queryKey: queryParamName,
-        queryValue: inputValue
+        queryValue: inputValue,
     };
 
     useEffect(() => {
         updatePath();
-    }, [location.pathname])
+    }, [location.pathname]);
+
+    useEffect(()=>{
+        updateQueryFromURL(pageParam, query)
+    },[pageParam, query]);
 
     const onInputChange = ({ target }) => {
         const trimmedValue = target.value.trim();
@@ -50,7 +56,7 @@ export const Search = () => {
 
     useEffect(() => {
         replaceQueryParameter(params);
-    }, [inputValue, currentPage, query, pageParam])
+    }, [inputValue, currentPage, query, pageParam]);
 
     return (
         <Wrapper>

--- a/src/common/Navigation/Search/searchSaga.js
+++ b/src/common/Navigation/Search/searchSaga.js
@@ -13,6 +13,7 @@ import {
     goToFirstSearchPage,
     goToLastSearchPage,
     setTotalResults,
+    searchPageNumberFromURL,
 } from "./searchSlice";
 import { getSearch } from "../../../utils/API/getSearch";
 import { getGenreList } from "../../../utils/API/getGenreList";
@@ -56,6 +57,7 @@ export function* searchSaga() {
             decrementPage,
             goToFirstSearchPage,
             goToLastSearchPage,
+            searchPageNumberFromURL,
         ],
         fetchDataHandler
     )

--- a/src/common/Navigation/Search/searchSlice.js
+++ b/src/common/Navigation/Search/searchSlice.js
@@ -1,4 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
+// import { createPaginationActions } from "../../Pagination/createPaginationActions";
+
+// const { paginationReducers } = createPaginationActions('searchSlice');
 
 const searchSlice = createSlice({
     name: "search",
@@ -15,10 +18,6 @@ const searchSlice = createSlice({
     reducers: {
         setPath: (state, { payload: path }) => {
             state.path = path;
-        },
-        setLoading: (state, { payload: data }) => {
-            state.status = "loading"
-            state.data = data;
         },
         setGenres: (state, { payload: genresList }) => {
             state.genres = genresList.genres;
@@ -42,6 +41,7 @@ const searchSlice = createSlice({
             state.status = "loading"
             state.inputValue = query;
         },
+        // ...paginationReducers,
         incrementPage: (state) => {
             state.page += 1;
             state.status = "loading";
@@ -57,7 +57,11 @@ const searchSlice = createSlice({
         goToLastSearchPage: (state, { payload: lastPage }) => {
             state.page = +lastPage;
             state.status = "loading";
-        }
+        },
+        searchPageNumberFromURL: (state, { payload: query }) => {
+            state.page = +query;
+            state.status = "loading";
+        },
     },
 });
 
@@ -77,13 +81,13 @@ export const {
     fetchDataSucces,
     setInputValue,
     setGenres,
-    setLoading,
     setTotalPages,
     setTotalResults,
     incrementPage,
     decrementPage,
     goToFirstSearchPage,
     goToLastSearchPage,
+    searchPageNumberFromURL,
 } = searchSlice.actions;
 
 export default searchSlice.reducer;

--- a/src/features/movies/MovieDetails/index.js
+++ b/src/features/movies/MovieDetails/index.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   setMovieId,
@@ -29,11 +29,13 @@ function MovieDetails() {
   const { id } = useParams();
   const dispatch = useDispatch();
   const location = useLocation();
+  const history = useHistory();
 
   useEffect(() => {
     dispatch(setMovieId(id))
     dispatch(setInputValue(``));
     dispatch(goToFirstSearchPage())
+    history.push(`${location.pathname}`);
   }, [location.pathname]);
 
   const status = useSelector(selectStatus);

--- a/src/features/people/PeopleDetails/index.js
+++ b/src/features/people/PeopleDetails/index.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams, useLocation, useHistory } from "react-router-dom";
 import {
   selectStatus,
   selectDetails,
@@ -28,6 +28,7 @@ const PersonDetails = () => {
   const dispatch = useDispatch();
   const { id } = useParams();
   const location = useLocation();
+  const history = useHistory();
 
   useEffect(() => {
     dispatch(getDetailsForPerson({ personId: id }));
@@ -36,6 +37,7 @@ const PersonDetails = () => {
   useEffect(() => {
     dispatch(setInputValue(``));
     dispatch(goToFirstSearchPage());
+    history.push(`${location.pathname}`);
   }, [location.pathname]);
 
   const details = useSelector(selectDetails);

--- a/src/utils/queryParamName.js
+++ b/src/utils/queryParamName.js
@@ -1,0 +1,1 @@
+export default "search";

--- a/src/utils/useURLParams.js
+++ b/src/utils/useURLParams.js
@@ -1,7 +1,8 @@
 import { useLocation, useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { pageNumberFromURL as moviesPageNumber } from '../features/movies/MovieList/movieListSlice';
 import { pageNumberFromURL as peoplePageNumber } from '../features/people/PeopleList/peopleSlice';
+import { searchPageNumberFromURL, selectTotalPages, setInputValue } from '../common/Navigation/Search/searchSlice';
 import paginationParamName from './paginationParamName';
 import pageLimit from './pageLimit';
 
@@ -38,6 +39,39 @@ export const useUpdatePageFromURL = () => {
     };
 };
 
+export const useReplacePageParameter = () => {
+    const location = useLocation();
+    const history = useHistory();
+
+    return (value) => {
+        history.push(`${location.pathname}?${paginationParamName}=${value}`);
+    };
+};
+
+export const useUpdateQueryFromURL = () => {
+    const dispatch = useDispatch();
+    const totalPages = useSelector(selectTotalPages);
+
+    return (value, query) => {
+        if (!value || value < 1) {
+            return (
+                dispatch(searchPageNumberFromURL(1)),
+                dispatch(setInputValue(query))
+            )
+        } if (value >= (totalPages + 1)) {
+            return (
+                dispatch(searchPageNumberFromURL(totalPages)),
+                dispatch(setInputValue(query))
+            )
+        } else {
+            return (
+                dispatch(searchPageNumberFromURL(Math.floor(value))),
+                dispatch(setInputValue(query))
+            )
+        };
+    };
+};
+
 export const useReplaceQueryParameter = () => {
     const location = useLocation();
     const history = useHistory();
@@ -60,11 +94,4 @@ export const useReplaceQueryParameter = () => {
     }
 };
 
-export const useReplacePageParameter = () => {
-    const location = useLocation();
-    const history = useHistory();
 
-    return (value) => {
-        history.push(`${location.pathname}?${paginationParamName}=${value}`);
-    };
-};

--- a/src/utils/useURLParams.js
+++ b/src/utils/useURLParams.js
@@ -38,6 +38,28 @@ export const useUpdatePageFromURL = () => {
     };
 };
 
+export const useReplaceQueryParameter = () => {
+    const location = useLocation();
+    const history = useHistory();
+    const queryParams = new URLSearchParams(location.search);
+
+    return ({
+        pageKey,
+        pageValue,
+        queryKey,
+        queryValue }) => {
+
+        if (!queryValue) {
+            queryParams.delete(queryKey);
+        } else {
+            queryParams.set(pageKey, pageValue);
+            queryParams.set(queryKey, queryValue);
+
+            history.push(`${location.pathname}?${queryParams.toString()}`);
+        }
+    }
+};
+
 export const useReplacePageParameter = () => {
     const location = useLocation();
     const history = useHistory();

--- a/src/utils/useURLParams.js
+++ b/src/utils/useURLParams.js
@@ -14,6 +14,7 @@ export const useURLParameter = (arg) => {
 
 export const useUpdatePageFromURL = () => {
     const dispatch = useDispatch();
+    const totalPages = useSelector(selectTotalPages);
 
     return ({ key, value }) => {
 
@@ -36,7 +37,23 @@ export const useUpdatePageFromURL = () => {
                 return dispatch(peoplePageNumber(Math.floor(value)));
             }
         };
-    };
+
+        if (key === "search") {
+            if (!value || value < 1) {
+                return dispatch(searchPageNumberFromURL(1));
+            } if (value >= (totalPages + 1)) {
+                return dispatch(searchPageNumberFromURL(totalPages));
+            } else {
+                return dispatch(searchPageNumberFromURL(Math.floor(value)));
+            };
+        };
+    }
+};
+
+export const useUpdateQueryFromURL = () => {
+    const dispatch = useDispatch();
+
+    return (query) => dispatch(setInputValue(query));
 };
 
 export const useReplacePageParameter = () => {
@@ -45,30 +62,6 @@ export const useReplacePageParameter = () => {
 
     return (value) => {
         history.push(`${location.pathname}?${paginationParamName}=${value}`);
-    };
-};
-
-export const useUpdateQueryFromURL = () => {
-    const dispatch = useDispatch();
-    const totalPages = useSelector(selectTotalPages);
-
-    return (value, query) => {
-        if (!value || value < 1) {
-            return (
-                dispatch(searchPageNumberFromURL(1)),
-                dispatch(setInputValue(query))
-            )
-        } if (value >= (totalPages + 1)) {
-            return (
-                dispatch(searchPageNumberFromURL(totalPages)),
-                dispatch(setInputValue(query))
-            )
-        } else {
-            return (
-                dispatch(searchPageNumberFromURL(Math.floor(value))),
-                dispatch(setInputValue(query))
-            )
-        };
     };
 };
 


### PR DESCRIPTION
Guys, I've added a replaceQueryParameter hook to utils/useURLParams, and then I implemented it in _common\Navigation\Search\index.js_

**an issue:** If you searched for results and from them go to one of the details, the search params are left in URL, exapmple:
1. type `wonka` URL changes to `/movies?page=1&search=wonka`
2. click on Wonka movie for details, URL changes to `/movies/787699?page=1&search=wonka`

I think its because MovieDetail (and PeopleDetail alike) page does not update the URL in any way ?

**a second issue:** param order. I think its alphabetical so page comes before search. It would be more user friendly to have it the other way around, but I don't know how to achive that yet.

**a bug**: if You manually backspace the input, the search page disapears but `?page=1&search=w` is left in the URL 😩 

maybe You can think of something to addess issues above.

PS: so far in only pushes the path to URL, changeing manually does not affect the app yet.

