### PR TITLE
bug-fix genre Tags render properly on movie lists

### DIFF
--- a/src/utils/API/processApiData.js
+++ b/src/utils/API/processApiData.js
@@ -27,9 +27,11 @@ const listCounties = (productionCountries) => (
 
 const nameGenres = (genreIds, genres) => {
   if (Array.isArray(genreIds)) {
-    (genreIds || []).map(
-      (id) => genres.find(
-        (genre) => genre.id === id).name
+    return (
+      (genreIds || []).map(
+        (id) => genres.find(
+          (genre) => genre.id === id).name
+      )
     )
   } return ([]);
 };


### PR DESCRIPTION
Hi, here i fixed a small syntax error prevented genre Tags form rendering on movie Tiles, after latest merge