### PR TITLE
Common/URLSearchParams refactor

### DIFF
--- a/src/common/Navigation/Search/index.js
+++ b/src/common/Navigation/Search/index.js
@@ -1,70 +1,54 @@
 import { useSelector, useDispatch } from "react-redux";
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import { usePathname } from "./usePathname";
 import { Wrapper, Input, Icon } from "./styled";
 import {
-    selectInputValue,
     selectPath,
     setInputValue,
-    selectCurrnetPage
 } from "./searchSlice";
 import {
     useURLParameter,
     useUpdatePageFromURL,
-    useUpdateQueryFromURL,
-    useReplaceQueryParameter
 } from "../../../utils/useURLParams";
 import paginationParamName from "../../../utils/paginationParamName";
 import queryParamName from "../../../utils/queryParamName";
 
 export const Search = () => {
     const location = useLocation();
+    const history = useHistory();
     const dispatch = useDispatch();
     const updatePath = usePathname();
-
+    const updatePageFromURL = useUpdatePageFromURL();
+    
     const path = useSelector(selectPath);
-    const inputValue = useSelector(selectInputValue);
-    const currentPage = useSelector(selectCurrnetPage);
-
     const pageParam = useURLParameter(paginationParamName);
     const query = useURLParameter(queryParamName);
-    const replaceQueryParameter = useReplaceQueryParameter();
-    const updateQueryFromURL = useUpdateQueryFromURL();
-    const updatePageFromURL = useUpdatePageFromURL();
-
-    const params = {
-        pageKey: paginationParamName,
-        pageValue: currentPage,
-        queryKey: queryParamName,
-        queryValue: inputValue,
-    };
+    const searchParams = new URLSearchParams(location.search);
 
     useEffect(() => {
         updatePath();
-    }, [location.pathname]);
 
-    useEffect(() => {
-        updatePageFromURL({
-            key: "search",
-            value: +pageParam,
-        });
-    }, [pageParam]);
-
-    useEffect(() => {
-        updateQueryFromURL(query)
-    }, [query]);
-  
-    useEffect(() => {
-        replaceQueryParameter(params);
-    }, [inputValue, currentPage, query, pageParam]);
+        if (query) {
+            updatePageFromURL({
+                key: queryParamName,
+                value: +pageParam,
+            });
+            dispatch(setInputValue(query));
+        };
+    }, [location]);
 
     const onInputChange = ({ target }) => {
-        const trimmedValue = target.value.trim();
+        const inputQuery = target.value.trim() !== 0 ? target.value : undefined;
 
-        if (trimmedValue.length !== 0) {
-            dispatch(setInputValue(target.value));
-        } else dispatch(setInputValue(trimmedValue));
+        if (!inputQuery) {
+            searchParams.delete(queryParamName);
+        } else {
+            searchParams.set(queryParamName, inputQuery);
+            searchParams.set(paginationParamName, "1")
+        }
+
+        return history.push(`${location.pathname}?${searchParams.toString()}`);
     };
 
     return (
@@ -73,7 +57,7 @@ export const Search = () => {
             <Input
                 placeholder={`Search for ${path}...`}
                 onChange={onInputChange}
-                value={inputValue || ""}
+                value={query || ""}
             />
         </Wrapper>
     );

--- a/src/common/Navigation/Search/searchSaga.js
+++ b/src/common/Navigation/Search/searchSaga.js
@@ -1,4 +1,4 @@
-import { all, put, call, debounce, select, takeEvery } from "redux-saga/effects";
+import { all, put, call, debounce, select, takeEvery, delay, takeLatest } from "redux-saga/effects";
 import {
     fetchDataSucces,
     fetchDataFailure,
@@ -8,10 +8,6 @@ import {
     selectPath,
     setTotalPages,
     selectCurrnetPage,
-    incrementPage,
-    decrementPage,
-    goToFirstSearchPage,
-    goToLastSearchPage,
     setTotalResults,
     searchPageNumberFromURL,
 } from "./searchSlice";
@@ -21,6 +17,7 @@ import { processSearchResults } from "../../../utils/API/processApiData";
 
 function* fetchDataHandler() {
     try {
+        yield delay(400);
         const [query, path, page] = yield all([
             select(selectInputValue),
             select(selectPath),
@@ -51,15 +48,7 @@ function* fetchDataHandler() {
 };
 
 export function* searchSaga() {
-    yield debounce(500, setInputValue, fetchDataHandler);
-    yield takeEvery(
-        [
-            incrementPage,
-            decrementPage,
-            goToFirstSearchPage,
-            goToLastSearchPage,
-            searchPageNumberFromURL,
-        ],
-        fetchDataHandler
-    );
+    // yield debounce(500, setInputValue, fetchDataHandler);
+    yield takeLatest(setInputValue, fetchDataHandler);
+    yield takeEvery(searchPageNumberFromURL, fetchDataHandler);
 };

--- a/src/common/Navigation/Search/searchSlice.js
+++ b/src/common/Navigation/Search/searchSlice.js
@@ -1,7 +1,4 @@
 import { createSlice } from "@reduxjs/toolkit";
-// import { createPaginationActions } from "../../Pagination/createPaginationActions";
-
-// const { paginationReducers } = createPaginationActions('searchSlice');
 
 const searchSlice = createSlice({
     name: "search",
@@ -12,7 +9,7 @@ const searchSlice = createSlice({
         status: "",
         genres: [{}],
         totalResults: 0,
-        totalPages: 1,
+        totalPages: 0,
         page: 1,
     },
     reducers: {
@@ -41,23 +38,6 @@ const searchSlice = createSlice({
             state.status = "loading"
             state.inputValue = query;
         },
-        // ...paginationReducers,
-        incrementPage: (state) => {
-            state.page += 1;
-            state.status = "loading";
-        },
-        decrementPage: (state) => {
-            state.page -= 1;
-            state.status = "loading";
-        },
-        goToFirstSearchPage: (state) => {
-            state.page = 1;
-            state.status = "loading";
-        },
-        goToLastSearchPage: (state, { payload: lastPage }) => {
-            state.page = +lastPage;
-            state.status = "loading";
-        },
         searchPageNumberFromURL: (state, { payload: query }) => {
             state.page = +query;
             state.status = "loading";
@@ -83,10 +63,6 @@ export const {
     setGenres,
     setTotalPages,
     setTotalResults,
-    incrementPage,
-    decrementPage,
-    goToFirstSearchPage,
-    goToLastSearchPage,
     searchPageNumberFromURL,
 } = searchSlice.actions;
 

--- a/src/common/Navigation/Search/searchSlice.js
+++ b/src/common/Navigation/Search/searchSlice.js
@@ -1,4 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { createPaginationActions } from '../../Pagination/createPaginationActions';
+
+const { paginationReducers } = createPaginationActions('movieListSlice');
 
 const searchSlice = createSlice({
     name: "search",
@@ -13,6 +16,7 @@ const searchSlice = createSlice({
         page: 1,
     },
     reducers: {
+        ...paginationReducers,
         setPath: (state, { payload: path }) => {
             state.path = path;
         },
@@ -38,10 +42,6 @@ const searchSlice = createSlice({
             state.status = "loading"
             state.inputValue = query;
         },
-        searchPageNumberFromURL: (state, { payload: query }) => {
-            state.page = +query;
-            state.status = "loading";
-        },
     },
 });
 
@@ -63,7 +63,7 @@ export const {
     setGenres,
     setTotalPages,
     setTotalResults,
-    searchPageNumberFromURL,
+    pageNumberFromURL: searchPageNumberFromURL,
 } = searchSlice.actions;
 
 export default searchSlice.reducer;

--- a/src/common/Navigation/Search/usePathname.js
+++ b/src/common/Navigation/Search/usePathname.js
@@ -1,6 +1,8 @@
 import { useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { setPath } from "./searchSlice";
+import popularMoviesPathName from "../../../utils/popularMoviesPathName";
+import popularPeoplePathName from "../../../utils/popularPeoplePathName";
 
 export const usePathname = () => {
     const dispatch = useDispatch();
@@ -9,10 +11,10 @@ export const usePathname = () => {
 
     const updatePath = () => {
         switch (path) {
-            case "movies":
-                return dispatch(setPath("movies"));
-            case "people":
-                return dispatch(setPath("people"));
+            case popularMoviesPathName:
+                return dispatch(setPath(popularMoviesPathName));
+            case popularPeoplePathName:
+                return dispatch(setPath(popularPeoplePathName));
             default:
                 return dispatch(setPath(""));
         };

--- a/src/common/Pagination/createPaginationActions.js
+++ b/src/common/Pagination/createPaginationActions.js
@@ -1,18 +1,5 @@
 export const createPaginationActions = () => {
 	const paginationReducers = {
-		incrementPage: (state) => {
-			state.page += 1;
-		},
-		decrementPage: (state) => {
-			state.page -= 1;
-		},
-		goToFirstPage: (state) => {
-			state.page = 1;
-		},
-		goToLastPage: (state, { payload: lastPage }) => {
-            state.page = +lastPage;
-            state.status = "loading";
-        },
         pageNumberFromURL: (state, { payload: query }) => {
             state.page = +query;
             state.status = "loading";

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -1,6 +1,4 @@
 import { useHistory, useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { selectPageState } from '../../features/movies/MovieList/movieListSlice';
 import {
 	Wrapper,
 	StyledButton,
@@ -15,9 +13,9 @@ import {
 } from './styled';
 import pageLimit from "../../utils/pageLimit";
 import paginationParamName from '../../utils/paginationParamName';
+import { useEffect } from 'react';
 
 const Pagination = ({ totalPages }) => {
-	const currentPage = useSelector(selectPageState);
 	const location = useLocation();
 	const history = useHistory();
 
@@ -25,6 +23,30 @@ const Pagination = ({ totalPages }) => {
 	const pageParam = searchParams.get(paginationParamName);
 
 	const maxPages = totalPages || pageLimit;
+
+	const limitedPageParam = () => {
+		if (+pageParam < 1 || !pageParam) {
+			return 1;
+		} if (+pageParam >= (maxPages + 1)) {
+			return maxPages;
+		} else {
+			return Math.floor(+pageParam);
+		};
+	};
+
+	useEffect(() => {
+		if (+pageParam < 1) {
+			return (
+				searchParams.set(paginationParamName, 1),
+				history.push(`${location.pathname}?${searchParams.toString()}`)
+			);
+		} if (+pageParam >= (maxPages + 1)) {
+			return (
+				searchParams.set(paginationParamName, maxPages),
+				history.push(`${location.pathname}?${searchParams.toString()}`)
+			);
+		};
+	}, [pageParam])
 
 	const onIncrement = () => {
 		searchParams.set(paginationParamName, +pageParam + 1);
@@ -50,7 +72,7 @@ const Pagination = ({ totalPages }) => {
 		<Wrapper>
 			<StyledButton
 				onClick={onToFirstPage}
-				disabled={currentPage < 2}
+				disabled={+pageParam < 2}
 			>
 				<ChevronLeft />
 				<MobileChevronLeft />
@@ -58,27 +80,27 @@ const Pagination = ({ totalPages }) => {
 			</StyledButton>
 			<StyledButton
 				onClick={onDecrement}
-				disabled={currentPage < 2}
+				disabled={+pageParam < 2}
 			>
 				<ChevronLeft />
 				<ButtonText>Previous</ButtonText>
 			</StyledButton>
 			<TextContainer>
 				<RegularText>Page</RegularText>
-				<BoldText>{currentPage}</BoldText>
+				<BoldText>{limitedPageParam()}</BoldText>
 				<RegularText>of</RegularText>
 				<BoldText>{maxPages}</BoldText>
 			</TextContainer>
 			<StyledButton
 				onClick={onIncrement}
-				disabled={currentPage > (maxPages - 1)}
+				disabled={+pageParam > (maxPages - 1)}
 			>
 				<ButtonText>Next</ButtonText>
 				<Chevron />
 			</StyledButton>
 			<StyledButton
 				onClick={onToLastPage}
-				disabled={currentPage > (maxPages - 1)}
+				disabled={+pageParam > (maxPages - 1)}
 			>
 				<ButtonText>Last</ButtonText>
 				<Chevron />

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -1,4 +1,6 @@
-import { useDispatch } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectPageState } from '../../features/movies/MovieList/movieListSlice';
 import {
 	Wrapper,
 	StyledButton,
@@ -12,22 +14,42 @@ import {
 	BoldText,
 } from './styled';
 import pageLimit from "../../utils/pageLimit";
+import paginationParamName from '../../utils/paginationParamName';
 
-const Pagination = ({
-	currentPage,
-	goToFirstPage,
-	goToLastPage,
-	decrementPage,
-	incrementPage,
-	totalPages,
-}) => {
-	const dispatch = useDispatch();
+const Pagination = ({ totalPages }) => {
+	const currentPage = useSelector(selectPageState);
+	const location = useLocation();
+	const history = useHistory();
+
+	const searchParams = new URLSearchParams(location.search);
+	const pageParam = searchParams.get(paginationParamName);
+
 	const maxPages = totalPages || pageLimit;
+
+	const onIncrement = () => {
+		searchParams.set(paginationParamName, +pageParam + 1);
+		history.push(`${location.pathname}?${searchParams.toString()}`);
+	};
+
+	const onDecrement = () => {
+		searchParams.set(paginationParamName, +pageParam - 1);
+		history.push(`${location.pathname}?${searchParams.toString()}`);
+	};
+
+	const onToFirstPage = () => {
+		searchParams.set(paginationParamName, 1);
+		history.push(`${location.pathname}?${searchParams.toString()}`);
+	};
+
+	const onToLastPage = () => {
+		searchParams.set(paginationParamName, maxPages);
+		history.push(`${location.pathname}?${searchParams.toString()}`);
+	};
 
 	return (
 		<Wrapper>
 			<StyledButton
-				onClick={() => dispatch(goToFirstPage())}
+				onClick={onToFirstPage}
 				disabled={currentPage < 2}
 			>
 				<ChevronLeft />
@@ -35,7 +57,7 @@ const Pagination = ({
 				<ButtonText>First</ButtonText>
 			</StyledButton>
 			<StyledButton
-				onClick={() => dispatch(decrementPage())}
+				onClick={onDecrement}
 				disabled={currentPage < 2}
 			>
 				<ChevronLeft />
@@ -47,15 +69,15 @@ const Pagination = ({
 				<RegularText>of</RegularText>
 				<BoldText>{maxPages}</BoldText>
 			</TextContainer>
-			<StyledButton 
-				onClick={() => dispatch(incrementPage())}
+			<StyledButton
+				onClick={onIncrement}
 				disabled={currentPage > (maxPages - 1)}
 			>
 				<ButtonText>Next</ButtonText>
 				<Chevron />
 			</StyledButton>
-			<StyledButton 
-				onClick={() => dispatch(goToLastPage(maxPages))}
+			<StyledButton
+				onClick={onToLastPage}
 				disabled={currentPage > (maxPages - 1)}
 			>
 				<ButtonText>Last</ButtonText>

--- a/src/features/SearchPage/NoResults.js
+++ b/src/features/SearchPage/NoResults.js
@@ -1,14 +1,26 @@
+import { useSelector } from "react-redux";
+import {
+    selectCurrnetPage,
+    selectTotalPages,
+} from "../../common/Navigation/Search/searchSlice";
 import { Main } from "../../common/Main/Main";
 import { Section, SectionTitle } from "../../common/Section/Section";
 import { Wrapper } from "./styled";
 import { ReactComponent as IconEmpty } from "../../assets/icon-empty.svg";
 
 export const NoResults = ({ searchQuery }) => {
+    const currentPage = useSelector(selectCurrnetPage);
+    const totalPages = useSelector(selectTotalPages);
 
     return (
         <Main>
             <Section>
-                <SectionTitle>{`Sorry, there are no results for "${searchQuery}"`}</SectionTitle>
+                <SectionTitle>
+                    {currentPage > totalPages
+                        ? `Sorry, there are only ${totalPages} pages with results for "${searchQuery}"`
+                        : `Sorry, there are no results for "${searchQuery}"`
+                    }
+                </SectionTitle>
                 <Wrapper>
                     <IconEmpty />
                 </Wrapper>

--- a/src/features/SearchPage/SearchedMovies.js
+++ b/src/features/SearchPage/SearchedMovies.js
@@ -1,48 +1,53 @@
 import { useSelector } from "react-redux";
+import {
+  selectTotalPages,
+  searchPageNumberFromURL
+} from "../../common/Navigation/Search/searchSlice";
 import { Main } from "../../common/Main/Main";
 import { Section, SectionTitle } from "../../common/Section/Section";
 import { LargeListWrapper, StyledLink } from "../../common/Tile/styled";
 import { ListTileLarge } from "../../common/Tile/index";
-import AnimatedPage from "../../common/AnimatedPage";
 import Pagination from "../../common/Pagination";
-import { incrementPage, decrementPage, goToFirstSearchPage, goToLastSearchPage, selectCurrnetPage, selectTotalPages } from "../../common/Navigation/Search/searchSlice";
+import AnimatedPage from "../../common/AnimatedPage";
 
-export const SearchedMovies = ({ searchQuery, searchResults, totalResults }) => {
-    const result = searchResults;
-    const currentPage = useSelector(selectCurrnetPage);
-    const totalPages = useSelector(selectTotalPages);
+export const SearchedMovies = (
+  {
+    searchQuery,
+    searchResults,
+    totalResults
+  }) => {
+  const result = searchResults;
+  const totalPages = useSelector(selectTotalPages);
 
-    return (
-        <AnimatedPage>
-            <Main>
-                <Section>
-                    <SectionTitle>{`Search result for "${searchQuery}" (${totalResults})`}</SectionTitle>
-                    <LargeListWrapper>
-                        {result.map((movie) => (
-                            <li key={movie.id}>
-                                <StyledLink to={`/movies/${movie.id}`}>
-                                    <ListTileLarge
-                                        posterPath={movie.posterPath}
-                                        title={movie.title}
-                                        subtitle={movie.year}
-                                        tags={movie.namedGenres}
-                                        voteCount={movie.votes}
-                                        ratingValue={movie.rating}
-                                    />
-                                </StyledLink>
-                            </li>
-                        ))}
-                    </LargeListWrapper>
-                </Section>
-                <Pagination
-                    currentPage={currentPage}
-                    goToFirstPage={goToFirstSearchPage}
-                    incrementPage={incrementPage}
-                    decrementPage={decrementPage}
-                    goToLastPage={goToLastSearchPage}
-                    totalPages={totalPages}
-                />
-            </Main>
-        </AnimatedPage>
-    );
+  return (
+    <AnimatedPage>
+      <Main>
+        <Section>
+          <SectionTitle>
+            {`Search result for "${searchQuery}" (${totalResults})`}
+          </SectionTitle>
+          <LargeListWrapper>
+            {result.map((movie) => (
+              <li key={movie.id}>
+                <StyledLink to={`/movies/${movie.id}`}>
+                  <ListTileLarge
+                    posterPath={movie.posterPath}
+                    title={movie.title}
+                    subtitle={movie.year}
+                    tags={movie.namedGenres}
+                    voteCount={movie.votes}
+                    ratingValue={movie.rating}
+                  />
+                </StyledLink>
+              </li>
+            ))}
+          </LargeListWrapper>
+        </Section>
+        <Pagination
+          totalPages={totalPages}
+          pageNumberFromURL={searchPageNumberFromURL}
+        />
+      </Main>
+    </AnimatedPage>
+  );
 };

--- a/src/features/SearchPage/SearchedPeople.js
+++ b/src/features/SearchPage/SearchedPeople.js
@@ -1,47 +1,49 @@
 import { useSelector } from "react-redux";
+import {
+  selectTotalPages,
+  searchPageNumberFromURL
+} from "../../common/Navigation/Search/searchSlice";
 import { Main } from "../../common/Main/Main";
 import { Section, SectionTitle } from "../../common/Section/Section";
 import { SmallListWrapper, StyledLink } from "../../common/Tile/styled";
 import { ListTileSmall, } from "../../common/Tile";
 import Pagination from "../../common/Pagination";
-import { selectCurrnetPage, selectTotalPages } from "../../common/Navigation/Search/searchSlice";
-import { goToFirstSearchPage, goToLastSearchPage, incrementPage, decrementPage } from "../../common/Navigation/Search/searchSlice";
 import AnimatedPage from "../../common/AnimatedPage";
 
+export const SearchedPeople = (
+  {
+    searchQuery,
+    searchResults,
+    totalResults
+  }) => {
+  const result = searchResults;
+  const totalPages = useSelector(selectTotalPages);
 
-
-export const SearchedPeople = ({ searchQuery, searchResults, totalResults }) => {
-    const result = searchResults;
-    const currentPage = useSelector(selectCurrnetPage);
-    const totalPages = useSelector(selectTotalPages);
-
-    return (
-        <AnimatedPage>
-            <Main>
-                <Section>
-                    <SectionTitle>{`Search result for "${searchQuery}" (${totalResults})`}</SectionTitle>
-                    <SmallListWrapper>
-                        {result.map((person) => (
-                            <li key={person.id}>
-                                <StyledLink to={`/people/${person.id}`}>
-                                    <ListTileSmall
-                                        posterPath={person.profile_path}
-                                        title={person.name}
-                                    />
-                                </StyledLink>
-                            </li>
-                        ))}
-                    </SmallListWrapper>
-                </Section>
-                <Pagination
-                    currentPage={currentPage}
-                    goToFirstPage={goToFirstSearchPage}
-                    incrementPage={incrementPage}
-                    decrementPage={decrementPage}
-                    goToLastPage={goToLastSearchPage}
-                    totalPages={totalPages}
-                />
-            </Main>
-        </AnimatedPage>
-    )
+  return (
+    <AnimatedPage>
+      <Main>
+        <Section>
+          <SectionTitle>
+            {`Search result for "${searchQuery}" (${totalResults})`}
+          </SectionTitle>
+          <SmallListWrapper>
+            {result.map((person) => (
+              <li key={person.id}>
+                <StyledLink to={`/people/${person.id}`}>
+                  <ListTileSmall
+                    posterPath={person.profile_path}
+                    title={person.name}
+                  />
+                </StyledLink>
+              </li>
+            ))}
+          </SmallListWrapper>
+        </Section>
+        <Pagination
+          totalPages={totalPages}
+          pageNumberFromURL={searchPageNumberFromURL}
+        />
+      </Main>
+    </AnimatedPage>
+  )
 }

--- a/src/features/SearchPage/index.js
+++ b/src/features/SearchPage/index.js
@@ -4,11 +4,13 @@ import {
     selectInputValue,
     selectPath,
     selectStatus,
-    selectTotalResults
+    selectTotalResults,
 } from "../../common/Navigation/Search/searchSlice";
 import { NoResults } from "./NoResults";
 import { SearchedMovies } from "./SearchedMovies";
 import { SearchedPeople } from "./SearchedPeople";
+import popularMoviesPathName from "../../utils/popularMoviesPathName";
+import popularPeoplePathName from "../../utils/popularPeoplePathName";
 import Loading from "../../common/Loading";
 import Error from "../../common/Error";
 
@@ -35,7 +37,7 @@ export const SearchPage = () => {
             return <Error />;
 
         default:
-            if (path === "movies") {
+            if (path === popularMoviesPathName) {
                 return <SearchedMovies
                     searchQuery={searchQuery}
                     searchResults={searchResults}
@@ -43,7 +45,7 @@ export const SearchPage = () => {
                 />
             };
 
-            if (path === "people") {
+            if (path === popularPeoplePathName) {
                 return <SearchedPeople
                     searchQuery={searchQuery}
                     searchResults={searchResults}

--- a/src/features/movies/MovieDetails/index.js
+++ b/src/features/movies/MovieDetails/index.js
@@ -15,12 +15,14 @@ import {
   setInputValue,
   selectData
 } from '../../../common/Navigation/Search/searchSlice';
+import { useURLParameter } from '../../../utils/useURLParams';
 import { BackdropHeader } from './Backdrop';
 import { Main } from '../../../common/Main/Main';
 import { Section, SectionTitle } from '../../../common/Section/Section';
 import { DetailsTile, ListTileSmall } from '../../../common/Tile';
 import { SmallListWrapper, StyledLink } from '../../../common/Tile/styled';
 import { SearchPage } from '../../SearchPage';
+import queryParamName from '../../../utils/queryParamName';
 import Error from '../../../common/Error';
 import Loading from '../../../common/Loading';
 import AnimatedPage from '../../../common/AnimatedPage';
@@ -30,6 +32,8 @@ function MovieDetails() {
   const dispatch = useDispatch();
   const location = useLocation();
   const history = useHistory();
+
+  const query = useURLParameter(queryParamName);
 
   useEffect(() => {
     dispatch(setMovieId(id))

--- a/src/features/movies/MovieDetails/index.js
+++ b/src/features/movies/MovieDetails/index.js
@@ -10,7 +10,6 @@ import {
   setError,
 } from './movieSlice';
 import {
-  goToFirstSearchPage,
   selectInputValue,
   setInputValue,
   selectData
@@ -34,7 +33,6 @@ function MovieDetails() {
   useEffect(() => {
     dispatch(setMovieId(id))
     dispatch(setInputValue(``));
-    dispatch(goToFirstSearchPage())
     history.push(`${location.pathname}`);
   }, [location.pathname]);
 

--- a/src/features/movies/MovieDetails/index.js
+++ b/src/features/movies/MovieDetails/index.js
@@ -15,14 +15,12 @@ import {
   setInputValue,
   selectData
 } from '../../../common/Navigation/Search/searchSlice';
-import { useURLParameter } from '../../../utils/useURLParams';
 import { BackdropHeader } from './Backdrop';
 import { Main } from '../../../common/Main/Main';
 import { Section, SectionTitle } from '../../../common/Section/Section';
 import { DetailsTile, ListTileSmall } from '../../../common/Tile';
 import { SmallListWrapper, StyledLink } from '../../../common/Tile/styled';
 import { SearchPage } from '../../SearchPage';
-import queryParamName from '../../../utils/queryParamName';
 import Error from '../../../common/Error';
 import Loading from '../../../common/Loading';
 import AnimatedPage from '../../../common/AnimatedPage';
@@ -32,8 +30,6 @@ function MovieDetails() {
   const dispatch = useDispatch();
   const location = useLocation();
   const history = useHistory();
-
-  const query = useURLParameter(queryParamName);
 
   useEffect(() => {
     dispatch(setMovieId(id))

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -1,20 +1,15 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  incrementPage,
-  decrementPage,
-  goToFirstPage,
-  goToLastPage,
   selectMovieList,
-  selectPageState,
   selectStatus,
   setError,
+  pageNumberFromURL,
 } from "./movieListSlice";
 import {
   setInputValue,
-  goToFirstSearchPage,
   selectData,
-  selectInputValue
 } from '../../../common/Navigation/Search/searchSlice';
 import {
   useURLParameter,
@@ -27,41 +22,42 @@ import { ListTileLarge } from '../../../common/Tile';
 import { StyledLink, LargeListWrapper } from '../../../common/Tile/styled';
 import { SearchPage } from '../../SearchPage';
 import paginationParamName from '../../../utils/paginationParamName';
+import queryParamName from '../../../utils/queryParamName';
+import popularMoviesPathName from '../../../utils/popularMoviesPathName';
 import Pagination from '../../../common/Pagination/index';
 import Error from '../../../common/Error';
 import Loading from '../../../common/Loading';
 import AnimatedPage from '../../../common/AnimatedPage';
 
 function MovieList() {
-  const currentPage = useSelector(selectPageState);
+  const dispatch = useDispatch();
+  const location = useLocation();
+
   const popularMovies = useSelector(selectMovieList);
   const status = useSelector(selectStatus);
-  const dispatch = useDispatch();
   const searchResults = useSelector(selectData);
-  const searchQuery = useSelector(selectInputValue);
 
-  const paramValue = useURLParameter(paginationParamName);
-  const params = {
-    key: "movies",
-    value: paramValue,
-  };
   const updatePageFromURL = useUpdatePageFromURL();
   const replacePageParameter = useReplacePageParameter();
+  const query = useURLParameter(queryParamName);
+  const pageParam = useURLParameter(paginationParamName);
+  const params = {
+    key: query ? queryParamName : popularMoviesPathName,
+    value: pageParam,
+  };
 
   useEffect(() => {
-    updatePageFromURL(params);
-  }, [paramValue]);
+    replacePageParameter(pageParam);
 
-  useEffect(() => {
-    replacePageParameter(currentPage);
-  }, [currentPage]);
+    if (!query) {
+      dispatch(setInputValue(""));
+      updatePageFromURL(params);
+    } else
+      updatePageFromURL(params);
+      dispatch(setInputValue(query));
+  }, [location]);
 
-  useEffect(() => {
-    dispatch(setInputValue(``));
-    dispatch(goToFirstSearchPage());
-  }, []);
-
-  if (searchResults && searchQuery) {
+  if (searchResults && query) {
     return <SearchPage />
   };
 
@@ -99,11 +95,7 @@ function MovieList() {
               </LargeListWrapper>
             </Section>
             <Pagination
-              currentPage={currentPage}
-              goToFirstPage={goToFirstPage}
-              incrementPage={incrementPage}
-              decrementPage={decrementPage}
-              goToLastPage={goToLastPage}
+              pageNumberFromURL={pageNumberFromURL}
             />
           </Main>
         </AnimatedPage>

--- a/src/features/movies/MovieList/movieListSaga.js
+++ b/src/features/movies/MovieList/movieListSaga.js
@@ -1,8 +1,8 @@
 import { all, call, put, takeEvery, select } from "redux-saga/effects";
 import {
-    incrementPage,
-    decrementPage,
-    goToFirstPage,
+    // incrementPage,
+    // decrementPage,
+    // goToFirstPage,
     pageNumberFromURL,
     selectPageState,
     setMovieList,
@@ -35,12 +35,5 @@ function* fetchMovieListHandler() {
 };
 
 export function* watchFetchMovieList() {
-    yield takeEvery(
-        [
-            incrementPage,
-            decrementPage,
-            goToFirstPage,
-            pageNumberFromURL
-        ],
-        fetchMovieListHandler);
+    yield takeEvery(pageNumberFromURL, fetchMovieListHandler);
 };

--- a/src/features/movies/MovieList/movieListSlice.js
+++ b/src/features/movies/MovieList/movieListSlice.js
@@ -29,10 +29,6 @@ const movieListSlice = createSlice({
 });
 
 export const {
-    incrementPage,
-    decrementPage,
-    goToFirstPage,
-    goToLastPage,
     pageNumberFromURL,
     setMovieList,
     setGenres,

--- a/src/features/people/PeopleDetails/index.js
+++ b/src/features/people/PeopleDetails/index.js
@@ -10,7 +10,6 @@ import {
   setError,
 } from "./peopleDetailsSlice";
 import {
-  goToFirstSearchPage,
   selectInputValue,
   setInputValue,
   selectData
@@ -36,7 +35,6 @@ const PersonDetails = () => {
 
   useEffect(() => {
     dispatch(setInputValue(``));
-    dispatch(goToFirstSearchPage());
     history.push(`${location.pathname}`);
   }, [location.pathname]);
 

--- a/src/features/people/PeopleList/index.js
+++ b/src/features/people/PeopleList/index.js
@@ -23,7 +23,7 @@ import { ListTileSmall } from '../../../common/Tile';
 import { SearchPage } from '../../SearchPage';
 import paginationParamName from '../../../utils/paginationParamName';
 import queryParamName from '../../../utils/queryParamName';
-import popularPeoplePathName from '../../../utils/popularMoviesPathName';
+import popularPeoplePathName from '../../../utils/popularPeoplePathName';
 import Pagination from '../../../common/Pagination';
 import Error from '../../../common/Error';
 import Loading from '../../../common/Loading';

--- a/src/features/people/PeopleList/index.js
+++ b/src/features/people/PeopleList/index.js
@@ -1,69 +1,63 @@
 import { useEffect } from 'react';
-import { useSelector,useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
 import {
-  incrementPage,
-  decrementPage,
-  goToFirstPage,
-  goToLastPage,
-  selectPageState,
   selectPeopleList,
   selectStatus,
   setError,
+  pageNumberFromURL,
 } from './peopleSlice';
-import { 
-  selectInputValue, 
-  selectData, 
-  setInputValue, 
-  goToFirstSearchPage 
+import {
+  selectData,
+  setInputValue,
 } from '../../../common/Navigation/Search/searchSlice';
-import { 
-  useURLParameter, 
-  useUpdatePageFromURL, 
-  useReplacePageParameter 
+import {
+  useURLParameter,
+  useUpdatePageFromURL,
+  useReplacePageParameter
 } from '../../../utils/useURLParams';
-
 import { Main } from '../../../common/Main/Main';
 import { Section, SectionTitle } from "../../../common/Section/Section";
 import { SmallListWrapper, StyledLink } from '../../../common/Tile/styled';
 import { ListTileSmall } from '../../../common/Tile';
 import { SearchPage } from '../../SearchPage';
 import paginationParamName from '../../../utils/paginationParamName';
+import queryParamName from '../../../utils/queryParamName';
+import popularPeoplePathName from '../../../utils/popularMoviesPathName';
 import Pagination from '../../../common/Pagination';
 import Error from '../../../common/Error';
 import Loading from '../../../common/Loading';
 import AnimatedPage from '../../../common/AnimatedPage';
 
-
 function PeopleList() {
-  const currentPage = useSelector(selectPageState);
+  const dispatch = useDispatch();
+  const location = useLocation();
+  
   const peopleList = useSelector(selectPeopleList);
   const status = useSelector(selectStatus);
-  const searchQuery = useSelector(selectInputValue);
   const searchResults = useSelector(selectData);
-  const dispatch = useDispatch();
 
-  const paramValue = useURLParameter(paginationParamName);
-  const params = {
-    key: "people",
-    value: paramValue,
-  };
   const updatePageFromURL = useUpdatePageFromURL();
   const replacePageParameter = useReplacePageParameter();
+  const query = useURLParameter(queryParamName);
+  const pageParam = useURLParameter(paginationParamName);
+  const params = {
+    key: query ? queryParamName : popularPeoplePathName,
+    value: pageParam,
+  };
 
   useEffect(() => {
-    updatePageFromURL(params);
-  }, [paramValue]);
+    replacePageParameter(pageParam);
 
-  useEffect(() => {
-    replacePageParameter(currentPage);
-  }, [currentPage]);
+    if (!query) {
+      dispatch(setInputValue(""));
+      updatePageFromURL(params);
+    } else
+      updatePageFromURL(params);
+      dispatch(setInputValue(query));
+  }, [location]);
 
-  useEffect(() => {
-    dispatch(setInputValue(""));
-    dispatch(goToFirstSearchPage());
-  }, []);
-
-  if (searchQuery && searchResults) {
+  if (searchResults && query) {
     return <SearchPage />
   }
 
@@ -97,11 +91,7 @@ function PeopleList() {
               </SmallListWrapper>
             </Section>
             <Pagination
-              currentPage={currentPage}
-              goToFirstPage={goToFirstPage}
-              incrementPage={incrementPage}
-              decrementPage={decrementPage}
-              goToLastPage={goToLastPage}
+              pageNumberFromURL={pageNumberFromURL}
             />
           </Main>
         </AnimatedPage>

--- a/src/features/people/PeopleList/peopleSaga.js
+++ b/src/features/people/PeopleList/peopleSaga.js
@@ -1,8 +1,5 @@
 import { call, put, takeEvery, select } from 'redux-saga/effects'
 import {
-    incrementPage,
-    decrementPage,
-    goToFirstPage,
     pageNumberFromURL,
     setPeopleList,
     selectPageState,
@@ -22,10 +19,5 @@ function* fetchPeopleListHandler() {
 }
 
 export function* peopleSaga() {
-    yield takeEvery([
-        incrementPage,
-        decrementPage,
-        goToFirstPage,
-        pageNumberFromURL],
-        fetchPeopleListHandler);
+    yield takeEvery(pageNumberFromURL, fetchPeopleListHandler);
 }

--- a/src/features/people/PeopleList/peopleSlice.js
+++ b/src/features/people/PeopleList/peopleSlice.js
@@ -27,10 +27,6 @@ const peopleSlice = createSlice({
 });
 
 export const {
-    incrementPage,
-    decrementPage,
-    goToFirstPage,
-    goToLastPage,
     pageNumberFromURL,
     setPeopleList,
     setError,

--- a/src/utils/API/getSearch.js
+++ b/src/utils/API/getSearch.js
@@ -1,14 +1,16 @@
 import axios from "axios";
 import { URL, AuthorizationAndLanguage } from "./APIURLS";
+import popularMoviesPathName from "../popularMoviesPathName";
+import popularPeoplePathName from "../popularPeoplePathName";
 
 export const getSearch = async (query, path, page) => {
 
     const searchPath = () => {
         switch (path) {
-            case "movies":
+            case popularMoviesPathName:
                 return "movie";
 
-            case "people":
+            case popularPeoplePathName:
                 return "person";
 
             default:

--- a/src/utils/API/processApiData.js
+++ b/src/utils/API/processApiData.js
@@ -1,4 +1,6 @@
 import { backdropURL, posterURL } from "./APIURLS";
+import popularMoviesPathName from "../popularMoviesPathName";
+import popularPeoplePathName from "../popularPeoplePathName";
 
 const getReleaseYear = (releaseDate) => {
   if (releaseDate && typeof releaseDate === "string") {
@@ -156,9 +158,9 @@ export const processPersonCreditsData = (rawCredits, rawGenreList) => {
 export const processSearchResults = (rawSearchResults, rawGenreList, path) => {
 
   switch (path) {
-    case "movies":
+    case popularMoviesPathName:
       return processMovieListData(rawSearchResults, rawGenreList);
-    case "people":
+    case popularPeoplePathName:
       return rawSearchResults.results;
     default:
       return {};

--- a/src/utils/popularMoviesPathName.js
+++ b/src/utils/popularMoviesPathName.js
@@ -1,0 +1,1 @@
+export default "movies";

--- a/src/utils/popularPeoplePathName.js
+++ b/src/utils/popularPeoplePathName.js
@@ -1,0 +1,1 @@
+export default "people";

--- a/src/utils/useURLParams.js
+++ b/src/utils/useURLParams.js
@@ -19,7 +19,7 @@ export const useUpdatePageFromURL = () => {
     return ({ key, value }) => {
 
         if (key === "movies") {
-            if (value < 1) {
+            if (value < 1 || !value) {
                 return dispatch(moviesPageNumber(1));
             } if (value >= (pageLimit + 1)) {
                 return dispatch(moviesPageNumber(pageLimit));
@@ -29,7 +29,7 @@ export const useUpdatePageFromURL = () => {
         };
 
         if (key === "people") {
-            if (value < 1) {
+            if (value < 1 || !value) {
                 return dispatch(peoplePageNumber(1));
             } if (value >= (pageLimit + 1)) {
                 return dispatch(peoplePageNumber(pageLimit));
@@ -41,7 +41,7 @@ export const useUpdatePageFromURL = () => {
         if (key === "search") {
             if (!value || value < 1) {
                 return dispatch(searchPageNumberFromURL(1));
-            } if (value >= (totalPages + 1)) {
+            } if (totalPages !== 0 && value >= (totalPages + 1)) {
                 return dispatch(searchPageNumberFromURL(totalPages));
             } else {
                 return dispatch(searchPageNumberFromURL(Math.floor(value)));
@@ -50,41 +50,23 @@ export const useUpdatePageFromURL = () => {
     }
 };
 
-export const useUpdateQueryFromURL = () => {
+export const useUpdateQueryFromURL = (query) => {
     const dispatch = useDispatch();
-
-    return (query) => dispatch(setInputValue(query));
+    if (query) {
+        return dispatch(setInputValue(query));
+    };
 };
 
 export const useReplacePageParameter = () => {
     const location = useLocation();
     const history = useHistory();
+    const searchParams = new URLSearchParams(location.search);
 
     return (value) => {
-        history.push(`${location.pathname}?${paginationParamName}=${value}`);
-    };
-};
 
-export const useReplaceQueryParameter = () => {
-    const location = useLocation();
-    const history = useHistory();
-    const queryParams = new URLSearchParams(location.search);
-
-    return ({
-        pageKey,
-        pageValue,
-        queryKey,
-        queryValue }) => {
-
-        if (!queryValue) {
-            queryParams.delete(queryKey);
-        } else {
-            queryParams.set(pageKey, pageValue);
-            queryParams.set(queryKey, queryValue);
-
-            history.push(`${location.pathname}?${queryParams.toString()}`);
-        }
+        if (!value) {
+            searchParams.set(paginationParamName, 1);
+        };
+        history.push(`${location.pathname}?${searchParams.toString()}`);
     }
 };
-
-

--- a/src/utils/useURLParams.js
+++ b/src/utils/useURLParams.js
@@ -4,6 +4,9 @@ import { pageNumberFromURL as moviesPageNumber } from '../features/movies/MovieL
 import { pageNumberFromURL as peoplePageNumber } from '../features/people/PeopleList/peopleSlice';
 import { searchPageNumberFromURL, selectTotalPages, setInputValue } from '../common/Navigation/Search/searchSlice';
 import paginationParamName from './paginationParamName';
+import queryParamName from './queryParamName';
+import popularMoviesPathName from './popularMoviesPathName';
+import popularPeoplePathName from './popularPeoplePathName';
 import pageLimit from './pageLimit';
 
 export const useURLParameter = (arg) => {
@@ -18,7 +21,7 @@ export const useUpdatePageFromURL = () => {
 
     return ({ key, value }) => {
 
-        if (key === "movies") {
+        if (key === popularMoviesPathName) {
             if (value < 1 || !value) {
                 return dispatch(moviesPageNumber(1));
             } if (value >= (pageLimit + 1)) {
@@ -28,7 +31,7 @@ export const useUpdatePageFromURL = () => {
             }
         };
 
-        if (key === "people") {
+        if (key === popularPeoplePathName) {
             if (value < 1 || !value) {
                 return dispatch(peoplePageNumber(1));
             } if (value >= (pageLimit + 1)) {
@@ -38,7 +41,7 @@ export const useUpdatePageFromURL = () => {
             }
         };
 
-        if (key === "search") {
+        if (key === queryParamName) {
             if (!value || value < 1) {
                 return dispatch(searchPageNumberFromURL(1));
             } if (totalPages !== 0 && value >= (totalPages + 1)) {


### PR DESCRIPTION
Like i've mentioned in #82 I've implemented a different approach, in this PR both paginations and search are based na URL params, only after the store is updated to fetch adequate data from API.

fixed bugs:

✔️ copying the URL does take us to the search page
✔️ deleting text from input clears search= param
✔️pagination resets when changing the input

as of the issue with param order in URL string, it seems I have no control over it.

🔴 one new thing creeped up: something in the new code broke watcher debounce behaviour.
🔴 a remaining issue: if You search for people or movies from person and movie details Page respectively, and then copy/paste the URL it will take you to that detail page not the search.

Otherwise I'm quite pleased with this solution. For sure its not optimal and can be refined, but it fixes major problems we encountered in previous tries.